### PR TITLE
Ensure propertyDefaults are working with class fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "can-reflect": "^1.17.10",
+    "can-type": "^1.1.4",
     "jshint": "^2.9.1",
     "steal": "^2.1.6",
     "steal-conditional": "^1.1.3",

--- a/src/can-observable-object.js
+++ b/src/can-observable-object.js
@@ -8,8 +8,6 @@ const {
 	mixinTypeEvents
 } = require("can-observable-mixin");
 
-const inSetupSymbol = Symbol.for("can.initializing");
-
 
 let ObservableObject = class extends mixinProxy(Object) {
 	constructor(props) {

--- a/src/can-observable-object.js
+++ b/src/can-observable-object.js
@@ -22,21 +22,22 @@ let ObservableObject = class extends mixinProxy(Object) {
 				const props = target.constructor.props;
 				let value = descriptor.value;
 
-				if (target.constructor.propertyDefaults) {
-					if (value && prop !== '_instanceDefinitions') {
+				// do not create expando properties for special keys set by can-observable-mixin
+				if (prop === '_instanceDefinitions') {
+					return Reflect.defineProperty(target, prop, descriptor);
+				}
+
+				// do not create expando properties for properties that are described
+				// by `static props` or `static propertyDefaults`
+				if (props && props[prop] || target.constructor.propertyDefaults) {
+					if (value) {
 						target.set(prop, value);
 						return true;
 					}
 					return Reflect.defineProperty(target, prop, descriptor);
 				}
 
-				// Don't overwrite static props
-				// that share the same name with a class field
-				if (props && props[prop]) {
-					obj[prop] = value;
-					return true;
-				}
-
+				// create expandos to make all other properties observable
 				return mixins.expando(target, prop, value);
 			}
 		});


### PR DESCRIPTION
Class fields should work with `propertyDefaults` behavior:
```js
class MyType extends ObservableObject {
		foo = 5;

		static propertyDefaults = {
			type: type.maybeConvert(String)
		};
	}

	const vm = new MyType();


	vm.on("foo", function(ev, newVal) {
		console.log(newVal); // "10"
	});

	vm.set("foo", 10);
```
#33 