### PR TITLE
Handle setKeyValue case

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "plugins": ["@babel/plugin-proposal-class-properties"],
   "presets": [
     [
       "@babel/preset-env",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+node_js: 12
 dist: xenial
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 12
+node_js: 10
 dist: xenial
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 10
+node_js: 10.14.2
 dist: xenial
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 10.14.2
+node_js: 12
 dist: xenial
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-node_js: 10.14.2
 dist: xenial
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 12
+node_js: 10.14.2
 dist: xenial
 services:
   - xvfb

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
+    "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/preset-env": "^7.4.5",
     "can-reflect": "^1.17.10",
     "can-type": "^1.1.4",

--- a/test/class-fields-test.js
+++ b/test/class-fields-test.js
@@ -1,6 +1,7 @@
 const ObservableObject = require("../src/can-observable-object");
 const type = require('can-type');
 const QUnit = require("steal-qunit");
+const canReflect = require('can-reflect');
 
 QUnit.module('can-observable-object-class-fields');
 
@@ -107,4 +108,31 @@ QUnit.test('Coerced properties for class fields', function(assert) {
 
 	vm.set("foo", 10);
 
+});
+
+QUnit.test('setKeyValue should event should be dispatched once', function(assert) {
+	assert.expect(1);
+
+	const done = assert.async();
+
+	class MyType extends ObservableObject {
+	}
+
+	const myType = new MyType();
+
+	canReflect.onKeyValue(myType, 'foo', (newVal) => {
+		assert.equal(newVal, 4);
+		done();
+	});
+
+	canReflect.setKeyValue(myType, 'foo', 4);
+});
+
+QUnit.test('observable mixin instances should have the proxied instance', function(assert) {
+	class MyType extends ObservableObject {
+	}
+
+	const myType = new MyType();
+
+	assert.ok(myType.constructor.instances.has(myType));
 });

--- a/test/class-fields-test.js
+++ b/test/class-fields-test.js
@@ -134,5 +134,5 @@ QUnit.test('observable mixin instances should have the proxied instance', functi
 
 	const myType = new MyType();
 
-	assert.ok(myType.constructor.instances.has(myType));
+	assert.ok(MyType.instances.has(myType));
 });


### PR DESCRIPTION
This fixes the case of setting properties with `canReflect.setKeyValue` that dispatches events more than once, the issue was caused after the changes to observable class fields:

```js
class MyType extends ObservableObject {
}

const myType = new MyType();

canReflect.onKeyValue(myType, 'foo', (newVal) => {
    console.log(newVal); // -> 4 will be logged once
});

canReflect.setKeyValue(myType, 'foo', 4);
```

Fixes #35 