### PR TITLE
Handle _data and _computed key in the proxy

### DIFF
--- a/src/can-observable-object.js
+++ b/src/can-observable-object.js
@@ -23,7 +23,8 @@ let ObservableObject = class extends mixinProxy(Object) {
 				let value = descriptor.value;
 
 				// do not create expando properties for special keys set by can-observable-mixin
-				if (prop === '_instanceDefinitions') {
+				const specialKeys = ['_instanceDefinitions', '_data', '_computed'];
+				if (specialKeys.indexOf(prop) >= 0) {
 					return Reflect.defineProperty(target, prop, descriptor);
 				}
 

--- a/test/class-fields-test.js
+++ b/test/class-fields-test.js
@@ -136,3 +136,11 @@ QUnit.test('observable mixin instances should have the proxied instance', functi
 
 	assert.ok(MyType.instances.has(myType));
 });
+
+// if(process.env.NODE_ENV === 'production') {
+// 	QUnit.test("Do not create expando properties for special keys set by can-observable-mixin", function(assert) {
+// 		let obj = new ObservableObject();
+// 		assert.ok(canReflect.getKeyValue(obj, '_data'));
+// 		assert.ok(canReflect.getKeyValue(obj, '_computed'));
+// 	});
+// }

--- a/test/class-fields-test.js
+++ b/test/class-fields-test.js
@@ -2,6 +2,7 @@ const ObservableObject = require("../src/can-observable-object");
 const type = require('can-type');
 const QUnit = require("steal-qunit");
 const canReflect = require('can-reflect');
+const clone = require('steal-clone');
 
 QUnit.module('can-observable-object-class-fields');
 
@@ -135,4 +136,24 @@ QUnit.test('observable mixin instances should have the proxied instance', functi
 	const myType = new MyType();
 
 	assert.ok(MyType.instances.has(myType));
+});
+
+
+QUnit.test('_data and _computed can be read in production mode', function(assert) {
+	const done = assert.async();
+	const oldEnv = window.process.env.NODE_ENV;
+	window.process.env.NODE_ENV = 'production';
+	clone()
+		.import("can-observable-object")
+		.then((ObservableObject) => {
+			class MyClass extends ObservableObject {
+				static props = {
+					foo: String
+				}
+			}
+			const obj = new MyClass();
+			assert.ok(obj._data);
+			window.process.env.NODE_ENV = oldEnv;
+			done();
+		});
 });

--- a/test/class-fields-test.js
+++ b/test/class-fields-test.js
@@ -136,11 +136,3 @@ QUnit.test('observable mixin instances should have the proxied instance', functi
 
 	assert.ok(MyType.instances.has(myType));
 });
-
-// if(process.env.NODE_ENV === 'production') {
-// 	QUnit.test("Do not create expando properties for special keys set by can-observable-mixin", function(assert) {
-// 		let obj = new ObservableObject();
-// 		assert.ok(canReflect.getKeyValue(obj, '_data'));
-// 		assert.ok(canReflect.getKeyValue(obj, '_computed'));
-// 	});
-// }


### PR DESCRIPTION
This handle `can-observable-mixin` special keys (_data and computed) to the proxy returned by the constructor.